### PR TITLE
feat(contract-api): use default for emit events in rollingStateOptions

### DIFF
--- a/packages/contract-api/src/offchainStateContract.ts
+++ b/packages/contract-api/src/offchainStateContract.ts
@@ -54,7 +54,6 @@ class OffchainStateContract extends SmartContract {
       ...this.rollingStateOptions,
       shouldEmitPrecondition: false,
       shouldEmitAccountUpdates: false,
-      shouldEmitEvents: true,
     };
   }
 
@@ -63,7 +62,6 @@ class OffchainStateContract extends SmartContract {
       ...this.rollingStateOptions,
       shouldEmitPrecondition: true,
       shouldEmitAccountUpdates: true,
-      shouldEmitEvents: true,
     };
   }
 


### PR DESCRIPTION
This change allows to use the default setting for `shouldEmitEvents`, when enabling and disabling rolling modes. As a result, it is possible to override the default `shouldEmitEvents` setting in `rollingStateOptions` of an `OffchainStateContract`, which basically disables emitting events altogether.