### PR TITLE
feat(contract-api): add .prove() and .restoreLatest()

### DIFF
--- a/packages/contract-api/src/contractApi.ts
+++ b/packages/contract-api/src/contractApi.ts
@@ -1,4 +1,4 @@
-import { Mina } from 'snarkyjs';
+import { Mina, type Proof, type ZkappPublicInput } from 'snarkyjs';
 import { VirtualStorage } from '@zkfs/virtual-storage';
 
 import type OffchainStateContract from './offchainStateContract.js';
@@ -12,6 +12,22 @@ type Transaction = Awaited<ReturnType<typeof Mina.transaction>>;
  */
 class ContractApi {
   public virtualStorage = new VirtualStorage();
+
+  /**
+   * This function restores the latest offchain state of a contract.
+   *
+   * @param {OffchainStateContract} contract - The `contract` parameter is
+   *  an instance of an `OffchainStateContract` class that needs to be restored
+   *  to its latest off-chain state.
+   */
+  // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+  public restoreLatest(contract: OffchainStateContract) {
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    Object.getPrototypeOf(
+      contract
+    ).constructor.offchainState.backup.restoreLatest(contract);
+  }
 
   /**
    * It assigns the virtual storage of this contract to
@@ -56,6 +72,38 @@ class ContractApi {
     return await Mina.transaction(sender, () => {
       transactionCallback();
     });
+  }
+
+  /**
+   * This function takes in a contract and a transaction callback, sets
+   * a flag to indicate that the contract is being proven, executes the
+   * transaction callback, and then sets the flag back to false.
+   *
+   * @param {OffchainStateContract} contract - OffchainStateContract
+   * the contract that you want to use
+   * @param transactionCallback
+   * This function is called to generate a proof for transaction of a contract.
+   *
+   * @returns the result of the `transactionCallback` function, which is
+   * expected to be a Promise that resolves to a Proof.
+   */
+  public async prove(
+    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
+    contract: OffchainStateContract,
+    transactionCallback: () => Promise<Proof<ZkappPublicInput>[] | undefined[]>
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const offchainStateBackup =
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      Object.getPrototypeOf(contract).constructor.offchainState.backup;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    offchainStateBackup.isProving = true;
+    const proofedTransaction = await transactionCallback();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    offchainStateBackup.isProving = false;
+
+    return proofedTransaction;
   }
 }
 

--- a/packages/contract-api/src/contractApi.ts
+++ b/packages/contract-api/src/contractApi.ts
@@ -91,7 +91,8 @@ class ContractApi {
     // eslint-disable-next-line max-len
     // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
     contract: OffchainStateContract,
-    transactionCallback: () => Promise<Proof<ZkappPublicInput>[] | undefined[]>
+    // eslint-disable-next-line putout/putout
+    transactionCallback: () => Promise<(Proof<ZkappPublicInput> | undefined)[]>
   ) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const offchainStateBackup =

--- a/packages/contract-api/src/offchainStateBackup.ts
+++ b/packages/contract-api/src/offchainStateBackup.ts
@@ -23,6 +23,8 @@ interface Backup {
 }
 
 class OffchainStateBackup {
+  public static isProving = false;
+
   public static virtualStorage = new VirtualStorage();
 
   public static virtualStorageBackup: Backup = { initial: {}, latest: {} };
@@ -32,6 +34,10 @@ class OffchainStateBackup {
   }
 
   public static backupInitial(target: OffchainStateContract) {
+    if (this.isProving) {
+      return;
+    }
+
     this.virtualStorageBackup.initial.maps = JSON.stringify(
       target.virtualStorage.maps
     );
@@ -41,6 +47,10 @@ class OffchainStateBackup {
   }
 
   public static backupLatest(target: OffchainStateContract) {
+    if (this.isProving) {
+      return;
+    }
+
     this.virtualStorageBackup.latest.maps = JSON.stringify(
       target.virtualStorage.maps
     );

--- a/packages/examples/test/piggyBank.test.ts
+++ b/packages/examples/test/piggyBank.test.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 /* eslint-disable jest/require-top-level-describe */
 
-import { AccountUpdate, UInt64 } from 'snarkyjs';
+import { AccountUpdate, type PublicKey, UInt64 } from 'snarkyjs';
 
 import PiggyBank from './piggyBank.js';
 import describeContract, { withTimer } from './describeContract.js';
@@ -28,15 +28,16 @@ describeContract<PiggyBank>('piggyBank', PiggyBank, (context) => {
         })
     );
 
-    await withTimer('prove', async () => {
-      await tx.prove();
-    });
+    await withTimer(
+      'prove',
+      async () => await contractApi.prove(zkApp, async () => await tx.prove())
+    );
 
     // this tx needs .sign(), because `deploy()` adds an account update
     // that requires signature authorization
     await tx.sign([deployerKey, zkAppPrivateKey]).send();
 
-    PiggyBank.offchainState.backup.restoreLatest(zkApp);
+    contractApi.restoreLatest(zkApp);
 
     return tx;
   }
@@ -68,28 +69,30 @@ describeContract<PiggyBank>('piggyBank', PiggyBank, (context) => {
         })
     );
 
-    await withTimer('prove', async () => await tx1.prove());
+    await withTimer(
+      'prove',
+      async () => await contractApi.prove(zkApp, async () => await tx1.prove())
+    );
     await tx1.sign([senderKey]).send();
 
-    PiggyBank.offchainState.backup.restoreLatest(zkApp);
+    contractApi.restoreLatest(zkApp);
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const key = `${zkApp.deposits.mapName!.toString()}-${zkApp
-      .getDepositKey(senderAccount)
-      .toString()}`;
-
-    const currentDepositAmount =
-      zkApp.virtualStorage.data[zkApp.address.toBase58()]?.[key]?.[0];
+    const [currentDepositAmount] = zkApp.deposits.get<PublicKey, UInt64>(
+      UInt64,
+      zkApp.getDepositKey(senderAccount)
+    );
 
     console.log('PiggyBank.initialDeposit() successful, new offchain state:', {
-      currentDepositAmount,
+      currentDepositAmount: currentDepositAmount.toString(),
       offchainStateRootHash: zkApp.offchainStateRootHash.get().toString(),
       data: zkApp.virtualStorage.data[zkApp.address.toBase58()],
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       tx: tx1.toPretty(),
     });
 
-    expect(currentDepositAmount).toStrictEqual(UInt64.from(10).toString());
+    expect(currentDepositAmount.toString()).toStrictEqual(
+      UInt64.from(10).toString()
+    );
 
     console.log('PiggyBank.deposit(), updating the offchain state...');
 
@@ -102,20 +105,25 @@ describeContract<PiggyBank>('piggyBank', PiggyBank, (context) => {
         })
     );
 
-    await withTimer('prove', async () => await tx2.prove());
+    await withTimer(
+      'prove',
+      async () => await contractApi.prove(zkApp, async () => await tx2.prove())
+    );
     await tx2.sign([senderKey]).send();
 
-    PiggyBank.offchainState.backup.restoreLatest(zkApp);
+    contractApi.restoreLatest(zkApp);
 
-    const currentUpdatedDepositAmount =
-      zkApp.virtualStorage.data[zkApp.address.toBase58()]?.[key]?.[0];
+    const [currentUpdatedDepositAmount] = zkApp.deposits.get<PublicKey, UInt64>(
+      UInt64,
+      zkApp.getDepositKey(senderAccount)
+    );
 
-    expect(currentUpdatedDepositAmount).toStrictEqual(
+    expect(currentUpdatedDepositAmount.toString()).toStrictEqual(
       UInt64.from(20).toString()
     );
 
     console.log('PiggyBank.deposit() successful, new offchain state:', {
-      currentUpdatedDepositAmount,
+      currentUpdatedDepositAmount: currentUpdatedDepositAmount.toString(),
       offchainStateRootHash: zkApp.offchainStateRootHash.get().toString(),
       data: zkApp.virtualStorage.data[zkApp.address.toBase58()],
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
This PR adds `.prove()` and `.restoreLatest()` to `contractApi`, in order to manage `offchainState` backups during transaction proving. This also resolves issues related to accessing `offchainState` outside of the zkApp for assertions.